### PR TITLE
CHORE: Add build option to docker-compose up

### DIFF
--- a/.github/workflows/docker-step-deploy.yml
+++ b/.github/workflows/docker-step-deploy.yml
@@ -46,4 +46,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - run: docker-compose --project-name ${{ inputs.PROJECT_NAME }} -f ${{ inputs.DOCKER_COMPOSE_PATH }} pull
       - run: docker-compose --project-name ${{ inputs.PROJECT_NAME }} -f ${{ inputs.DOCKER_COMPOSE_PATH }} down
-      - run: docker-compose --project-name ${{ inputs.PROJECT_NAME }} -f ${{ inputs.DOCKER_COMPOSE_PATH }} up -d
+      - run: docker-compose --project-name ${{ inputs.PROJECT_NAME }} -f ${{ inputs.DOCKER_COMPOSE_PATH }} up -d --build


### PR DESCRIPTION
Some docker-compose files might  build a docker image instead of using a pre-built one. We force building every time. This should not affect in any way docker-compose files that use pre-build images.