### PR TITLE
CHORE: Fix conventional commit release step

### DIFF
--- a/.github/workflows/conventional-commits-step-release.yml
+++ b/.github/workflows/conventional-commits-step-release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: npm
-          node-version: 18
+          node-version: 16
       - run: npm ci --ignore-scripts
       - run: npx semantic-release
         env:


### PR DESCRIPTION
We don't support node 18 within our native runner.