### PR TITLE
HOTFIX: Continue on Azure logout error

### DIFF
--- a/.github/actions/azure/storage/deploy/action.yml
+++ b/.github/actions/azure/storage/deploy/action.yml
@@ -52,6 +52,7 @@ runs:
     - name: Azure logout
       uses: azure/CLI@v1
       if: always()
+      continue-on-error: true
       with:
         inlineScript: |
           az logout


### PR DESCRIPTION
The Azure logout task fails with the error "ERROR: There are no active accounts.". Sometimes, the error is not triggered; I don't know why.

While I investigate further, I would like to avoid receiving error emails from the pipeline because the deploy failed (while only the logout failed).

Since logout is the last step, there are no implications on continuing the execution of the job in case of error.