### PR TITLE
fix: default workflow runner

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,9 +12,7 @@ concurrency:
 jobs:
   lint-pr:
     name: Lint PR
-    runs-on:
-      labels: 'zupit-agents'
-      group: 'Container'
+    runs-on: 'ubuntu-24.04'
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,8 +13,8 @@ jobs:
   lint-pr:
     name: Lint PR
     runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+      labels: 'zupit-agents'
+      group: 'Container'
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ jobs:
   release-npm:
     name: Release
     runs-on:
-      labels: ${{ inputs.RUN_ON }}
-      group: ${{ inputs.RUNNERS_CONTAINER_GROUP }}
+      labels: 'zupit-agents'
+      group: 'Container'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,7 @@ on:
 jobs:
   release-npm:
     name: Release
-    runs-on:
-      labels: 'zupit-agents'
-      group: 'Container'
+    runs-on: 'ubuntu-24.04'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Repo pubblico quindi non vede i runner condivisi nell'organization.
Dato che sono i runner per eseguire il tag della release e PR va bene ubuntu-24.04 in quanto non ha limiti per i repo pubblici.



## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] Does the code follow the team's coding standards and best practices?
- [ ] Are there any duplicated code blocks that can be refactored into reusable functions?
- [ ] Are there tests on the new code?
- [ ] Does the PR implement the intended functionality or fix the issue described in the title and description?
- [ ] Is the PR title clear and detailed enough to provide necessary context?
- [ ] Have the changes passed the CI/CD pipeline?
- [ ] Will the changes have any adverse effects on other parts of the system and do they work well with other existing features?
